### PR TITLE
Add extension exhaustive

### DIFF
--- a/app/src/main/java/com/jshvarts/healthreads/bookdetail/BookDetailFragment.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/bookdetail/BookDetailFragment.kt
@@ -13,6 +13,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.jshvarts.healthreads.R
 import com.jshvarts.healthreads.databinding.FragmentBookDetailBinding
 import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.util.exhaustive
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -50,7 +51,7 @@ class BookDetailFragment : Fragment() {
           is DetailViewState.Loading -> renderLoadingState()
           is DetailViewState.Error -> renderErrorState()
           is DetailViewState.Data -> renderDataState(it.book)
-        }
+        }.exhaustive
       }
     }
 

--- a/app/src/main/java/com/jshvarts/healthreads/booklist/BookListFragment.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/booklist/BookListFragment.kt
@@ -13,6 +13,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.jshvarts.healthreads.R
 import com.jshvarts.healthreads.databinding.FragmentBookListBinding
 import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.util.exhaustive
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class BookListFragment : Fragment() {
@@ -50,7 +51,7 @@ class BookListFragment : Fragment() {
         is BookListViewState.Loading -> renderLoadingState()
         is BookListViewState.Error -> renderErrorState()
         is BookListViewState.Data -> renderDataState(it.books)
-      }
+      }.exhaustive
     }
 
     binding.pullToRefresh.setOnRefreshListener {

--- a/app/src/main/java/com/jshvarts/healthreads/util/Extensions.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/util/Extensions.kt
@@ -1,0 +1,19 @@
+package com.jshvarts.healthreads.util
+
+/**
+ * Helper to force a when statement to assert all options are matched in a when statement.
+ *
+ * By default, Kotlin doesn't care if all branches are handled in a when statement. However, if you
+ * use the when statement as an expression (with a value) it will force all cases to be handled.
+ *
+ * This extension will force all cases to be handled in a when statement as well.
+ *
+ * Usage:
+ *
+ * when(sealedObject) {
+ *     is OneType -> ...
+ *     is AnotherType -> ...
+ * }.exhaustive
+ */
+val <T> T.exhaustive: T
+  get() = this


### PR DESCRIPTION
# Summary:

By default, Kotlin doesn't care if all branches are handled in a when statement. However, if you
use the when statement as an expression (with a value) it will force all cases to be handled.

This extension will force all cases to be handled in a when statement as well

<img width="765" alt="Screen Shot 2020-09-16 at 10 23 58 PM" src="https://user-images.githubusercontent.com/5749794/93412530-53d6da00-f86b-11ea-9cf0-2381b2ab2b77.png">
.
