### PR TITLE
Implement force refresh capability to bypass HTTP cache

### DIFF
--- a/app/src/main/java/com/jshvarts/healthreads/bookdetail/BookDetailFragment.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/bookdetail/BookDetailFragment.kt
@@ -30,7 +30,7 @@ class BookDetailFragment : Fragment() {
   private var snackbar: Snackbar? = null
 
   private val refreshOnErrorListener = View.OnClickListener {
-    loadBookDetail()
+    loadBookDetail(true)
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -62,10 +62,10 @@ class BookDetailFragment : Fragment() {
     }
 
     binding.pullToRefresh.setOnRefreshListener {
-      loadBookDetail()
+      loadBookDetail(true)
     }
 
-    loadBookDetail()
+    loadBookDetail(false)
   }
 
   override fun onDestroyView() {
@@ -107,7 +107,7 @@ class BookDetailFragment : Fragment() {
     binding.contributor.text = book.contributor
   }
 
-  private fun loadBookDetail() {
-    viewModel.getBookDetail(args.isbn)
+  private fun loadBookDetail(forceRefresh: Boolean) {
+    viewModel.getBookDetail(args.isbn, forceRefresh)
   }
 }

--- a/app/src/main/java/com/jshvarts/healthreads/bookdetail/BookDetailViewModel.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/bookdetail/BookDetailViewModel.kt
@@ -17,10 +17,10 @@ class BookDetailViewModel(
   private val _viewState = MutableStateFlow<DetailViewState>(DetailViewState.Loading)
   val viewState: StateFlow<DetailViewState> = _viewState
 
-  fun getBookDetail(isbn: String) {
+  fun getBookDetail(isbn: String, forceRefresh: Boolean) {
     viewModelScope.launch {
 
-      bookRepository.fetchBook(isbn)
+      bookRepository.fetchBook(isbn, forceRefresh)
         .onStart {
           _viewState.value = DetailViewState.Loading
         }

--- a/app/src/main/java/com/jshvarts/healthreads/booklist/BookListFragment.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/booklist/BookListFragment.kt
@@ -29,7 +29,7 @@ class BookListFragment : Fragment() {
   }
 
   private val refreshOnErrorListener = View.OnClickListener {
-    loadBookList()
+    loadBookList(true)
   }
 
   override fun onCreateView(
@@ -57,10 +57,10 @@ class BookListFragment : Fragment() {
     }
 
     binding.pullToRefresh.setOnRefreshListener {
-      loadBookList()
+      loadBookList(true)
     }
 
-    loadBookList()
+    loadBookList(false)
   }
 
   override fun onDestroyView() {
@@ -90,8 +90,8 @@ class BookListFragment : Fragment() {
     recyclerViewAdapter.submitList(books)
   }
 
-  private fun loadBookList() {
-    viewModel.getBooks()
+  private fun loadBookList(forceRefresh: Boolean) {
+    viewModel.getBooks(forceRefresh)
   }
 
   private fun onBookClicked(book: Book, bookImageView: ImageView) {

--- a/app/src/main/java/com/jshvarts/healthreads/booklist/BookListViewModel.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/booklist/BookListViewModel.kt
@@ -18,9 +18,9 @@ class BookListViewModel(
   private val _viewState = MutableLiveData<BookListViewState>()
   val viewState: LiveData<BookListViewState> = _viewState
 
-  fun getBooks() {
+  fun getBooks(forceRefresh: Boolean) {
     viewModelScope.launch {
-      bookRepository.fetchBooks()
+      bookRepository.fetchBooks(forceRefresh)
         .onStart {
           _viewState.value = BookListViewState.Loading
         }.catch { throwable ->

--- a/app/src/main/java/com/jshvarts/healthreads/data/Api.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/data/Api.kt
@@ -4,11 +4,21 @@ import com.jshvarts.healthreads.BuildConfig
 import com.jshvarts.healthreads.domain.Book
 import com.jshvarts.healthreads.domain.WrappedBookList
 import retrofit2.http.GET
+import retrofit2.http.Headers
+
+const val CACHE_CONTROL_HEADER = "Cache-Control"
+const val CACHE_CONTROL_NO_CACHE = "no-cache"
 
 private const val API_KEY = BuildConfig.NYT_API_KEY
+private const val FETCH_BOOKS_URL = "lists/current/health.json?api-key=$API_KEY"
 
 interface Api {
-  @GET(value = "lists/current/health.json?api-key=$API_KEY")
+  @GET(value = FETCH_BOOKS_URL)
   @WrappedBookList
   suspend fun fetchBooks(): List<Book>
+
+  @GET(value = FETCH_BOOKS_URL)
+  @WrappedBookList
+  @Headers("$CACHE_CONTROL_HEADER: $CACHE_CONTROL_NO_CACHE")
+  suspend fun fetchBooksForceRefresh(): List<Book>
 }

--- a/app/src/main/java/com/jshvarts/healthreads/data/BookRepository.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/data/BookRepository.kt
@@ -6,14 +6,24 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 
 class BookRepository(private val api: Api) {
-  suspend fun fetchBooks(): Flow<List<Book>> {
-    return flow { emit(api.fetchBooks()) }
+  suspend fun fetchBooks(forceRefresh: Boolean = false): Flow<List<Book>> {
+    return flow {
+      emit(callApi(forceRefresh))
+    }
   }
 
-  suspend fun fetchBook(isbn: String): Flow<Result<Book>> {
+  suspend fun fetchBook(isbn: String, forceRefresh: Boolean = false): Flow<Result<Book>> {
     return flow {
-      val book = api.fetchBooks().first { it.isbn == isbn }
+      val book = callApi(forceRefresh).first { it.isbn == isbn }
       emit(Result.success(book))
     }.catch { emit(Result.failure(it)) }
+  }
+
+  private suspend fun callApi(forceRefresh: Boolean): List<Book> {
+    return if (forceRefresh) {
+      api.fetchBooksForceRefresh()
+    } else {
+      api.fetchBooks()
+    }
   }
 }


### PR DESCRIPTION
# Summary

This PR adds ability to bypass HTTP cache when user uses pull-to-refresh. It works on both Book List and Book Detail screens. 

* When `forceRefresh` is passed in, `Cache-Control` header will not be present in HTTP response and cache won't be used. 
* When `forceRefresh` is not passed in, `Cache-Control: max-age=600` will be present in HTTP response and all subsequent request will be returning cached data.

# Testing
Manual testing on Pixel 2XL/OS 10 and added unit tests.