### PR TITLE
Implement offline mode using Room for persistence

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,13 +51,16 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation "com.google.android.material:material:1.2.0"
 
+    // Coil
+    implementation "io.coil-kt:coil:0.12.0"
+
     // Coroutines
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.8'
 
     // Koin
     implementation "org.koin:koin-android:$koin_version"
     implementation "org.koin:koin-androidx-viewmodel:$koin_version"
-
+    
     // Moshi
     implementation 'com.squareup.moshi:moshi-kotlin:1.9.2'
     kapt 'com.squareup.moshi:moshi-kotlin-codegen:1.9.2'
@@ -74,8 +77,11 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-moshi:2.8.1'
 
-    // Coil
-    implementation "io.coil-kt:coil:0.12.0"
+    // Room
+    def room_version = "2.2.5"
+    implementation "androidx.room:room-runtime:$room_version"
+    kapt "androidx.room:room-compiler:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
 
     // Timber
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/app/src/main/java/com/jshvarts/healthreads/data/BookRepository.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/data/BookRepository.kt
@@ -1,29 +1,44 @@
 package com.jshvarts.healthreads.data
 
+import com.jshvarts.healthreads.data.network.Api
+import com.jshvarts.healthreads.data.persistence.BookDao
 import com.jshvarts.healthreads.domain.Book
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 
-class BookRepository(private val api: Api) {
+class BookRepository(
+  private val api: Api,
+  private val bookDao: BookDao
+) {
   suspend fun fetchBooks(forceRefresh: Boolean = false): Flow<List<Book>> {
-    return flow {
-      emit(callApi(forceRefresh))
-    }
+    return flow { emit(loadBooks(forceRefresh)) }
   }
 
   suspend fun fetchBook(isbn: String, forceRefresh: Boolean = false): Flow<Result<Book>> {
     return flow {
-      val book = callApi(forceRefresh).first { it.isbn == isbn }
+      val book = loadBooks(forceRefresh).first { it.isbn == isbn }
       emit(Result.success(book))
     }.catch { emit(Result.failure(it)) }
   }
 
-  private suspend fun callApi(forceRefresh: Boolean): List<Book> {
+  private suspend fun loadBooks(forceRefresh: Boolean): List<Book> {
     return if (forceRefresh) {
-      api.fetchBooksForceRefresh()
+      refreshAndCache()
     } else {
-      api.fetchBooks()
+      bookDao.fetchBooks().also {
+        if (it.isEmpty()) {
+          return refreshAndCache()
+        }
+      }
+    }
+  }
+
+  private suspend fun refreshAndCache(): List<Book> {
+    return api.fetchBooks().also {
+      if (it.isNotEmpty()) {
+        bookDao.insertBooks(it)
+      }
     }
   }
 }

--- a/app/src/main/java/com/jshvarts/healthreads/data/network/Api.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/data/network/Api.kt
@@ -1,13 +1,9 @@
-package com.jshvarts.healthreads.data
+package com.jshvarts.healthreads.data.network
 
 import com.jshvarts.healthreads.BuildConfig
 import com.jshvarts.healthreads.domain.Book
 import com.jshvarts.healthreads.domain.WrappedBookList
 import retrofit2.http.GET
-import retrofit2.http.Headers
-
-const val CACHE_CONTROL_HEADER = "Cache-Control"
-const val CACHE_CONTROL_NO_CACHE = "no-cache"
 
 private const val API_KEY = BuildConfig.NYT_API_KEY
 private const val FETCH_BOOKS_URL = "lists/current/health.json?api-key=$API_KEY"
@@ -16,9 +12,4 @@ interface Api {
   @GET(value = FETCH_BOOKS_URL)
   @WrappedBookList
   suspend fun fetchBooks(): List<Book>
-
-  @GET(value = FETCH_BOOKS_URL)
-  @WrappedBookList
-  @Headers("$CACHE_CONTROL_HEADER: $CACHE_CONTROL_NO_CACHE")
-  suspend fun fetchBooksForceRefresh(): List<Book>
 }

--- a/app/src/main/java/com/jshvarts/healthreads/data/persistence/BookDao.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/data/persistence/BookDao.kt
@@ -1,0 +1,16 @@
+package com.jshvarts.healthreads.data.persistence
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.jshvarts.healthreads.domain.Book
+
+@Dao
+interface BookDao {
+  @Query("SELECT * FROM book")
+  suspend fun fetchBooks(): List<Book>
+
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun insertBooks(books: List<Book>)
+}

--- a/app/src/main/java/com/jshvarts/healthreads/data/persistence/BookDatabase.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/data/persistence/BookDatabase.kt
@@ -1,0 +1,30 @@
+package com.jshvarts.healthreads.data.persistence
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import com.jshvarts.healthreads.domain.Book
+
+private const val DATABASE_VERSION = 1
+
+@Database(
+  entities = [Book::class],
+  version = DATABASE_VERSION,
+  exportSchema = false
+)
+abstract class BookDatabase : RoomDatabase() {
+  companion object {
+    private const val DATABASE_NAME = "HealthBooks"
+
+    fun buildDatabase(context: Context): BookDatabase {
+      return Room.databaseBuilder(
+        context,
+        BookDatabase::class.java,
+        DATABASE_NAME
+      ).build()
+    }
+  }
+
+  abstract fun bookDao(): BookDao
+}

--- a/app/src/main/java/com/jshvarts/healthreads/di/networkModule.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/di/networkModule.kt
@@ -1,35 +1,21 @@
 package com.jshvarts.healthreads.di
 
-import android.app.Application
-import com.jshvarts.healthreads.data.Api
-import com.jshvarts.healthreads.data.CACHE_CONTROL_HEADER
-import com.jshvarts.healthreads.data.CACHE_CONTROL_NO_CACHE
+import com.jshvarts.healthreads.data.network.Api
 import com.jshvarts.healthreads.domain.BooksJsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import okhttp3.Cache
-import okhttp3.CacheControl
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.Response
 import okhttp3.logging.HttpLoggingInterceptor
-import org.koin.android.ext.koin.androidApplication
 import org.koin.dsl.module
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
-import java.util.concurrent.TimeUnit
 
 private const val BASE_URL = "https://api.nytimes.com/svc/books/v3/"
 
-private const val CACHE_SIZE = 5 * 1024 * 1024L // 5 MB
-
 val networkModule = module {
-  single {
-    httpCache(this.androidApplication())
-  }
 
   single {
-    okHttp(get())
+    okHttp()
   }
 
   single {
@@ -41,10 +27,8 @@ val networkModule = module {
   }
 }
 
-private fun okHttp(cache: Cache): OkHttpClient {
+private fun okHttp(): OkHttpClient {
   return OkHttpClient.Builder()
-    .cache(cache)
-    .addNetworkInterceptor(CacheInterceptor())
     .addInterceptor(loggingInterceptor())
     .build()
 }
@@ -60,28 +44,6 @@ private fun retrofit(okHttpClient: OkHttpClient) = Retrofit.Builder()
   .client(okHttpClient)
   .build()
 
-private fun httpCache(application: Application): Cache {
-  return Cache(application.applicationContext.cacheDir, CACHE_SIZE)
-}
-
 private fun loggingInterceptor() = HttpLoggingInterceptor().apply {
   level = HttpLoggingInterceptor.Level.HEADERS
-}
-
-class CacheInterceptor : Interceptor {
-  override fun intercept(chain: Interceptor.Chain): Response {
-    val request = chain.request()
-    val originalResponse = chain.proceed(request)
-
-    val shouldUseCache = request.header(CACHE_CONTROL_HEADER) != CACHE_CONTROL_NO_CACHE
-    if (!shouldUseCache) return originalResponse
-
-    val cacheControl = CacheControl.Builder()
-      .maxAge(10, TimeUnit.MINUTES)
-      .build()
-
-    return originalResponse.newBuilder()
-      .header(CACHE_CONTROL_HEADER, cacheControl.toString())
-      .build()
-  }
 }

--- a/app/src/main/java/com/jshvarts/healthreads/di/repoModule.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/di/repoModule.kt
@@ -1,8 +1,16 @@
 package com.jshvarts.healthreads.di
 
 import com.jshvarts.healthreads.data.BookRepository
+import com.jshvarts.healthreads.data.persistence.BookDatabase
+import org.koin.android.ext.koin.androidApplication
 import org.koin.dsl.module
 
 val repoModule = module {
-  single { BookRepository(get()) }
+  single {
+    BookDatabase.buildDatabase(androidApplication())
+  }
+
+  single { get<BookDatabase>().bookDao() }
+
+  single { BookRepository(get(), get()) }
 }

--- a/app/src/main/java/com/jshvarts/healthreads/domain/BookModels.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/domain/BookModels.kt
@@ -1,5 +1,8 @@
 package com.jshvarts.healthreads.domain
 
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
@@ -16,9 +19,11 @@ import com.squareup.moshi.ToJson
  * ----> { bookN }
  */
 @JsonClass(generateAdapter = true)
+@Entity(tableName = "book")
 data class Book(
-  val title: String,
+  @PrimaryKey
   @Json(name = "primary_isbn10") val isbn: String,
+  val title: String,
   @Json(name = "book_image") val imageUrl: String,
   val contributor: String
 )

--- a/app/src/test/java/com/jshvarts/healthreads/data/BookRepositoryTest.kt
+++ b/app/src/test/java/com/jshvarts/healthreads/data/BookRepositoryTest.kt
@@ -1,9 +1,13 @@
 package com.jshvarts.healthreads.data
 
+import com.jshvarts.healthreads.data.network.Api
+import com.jshvarts.healthreads.data.persistence.BookDao
 import com.jshvarts.healthreads.domain.Book
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.runBlocking
@@ -16,6 +20,7 @@ import kotlin.test.assertTrue
 private const val TEST_ISBN = "isbn1"
 
 class BookRepositoryTest {
+
   @Test
   fun `when book detail lookup succeeds, success result is emitted`() = runBlocking {
     // GIVEN
@@ -27,10 +32,14 @@ class BookRepositoryTest {
     )
 
     val api = mock<Api> {
+      onBlocking { fetchBooks() } doReturn emptyList()
+    }
+
+    val bookDao = mock<BookDao> {
       onBlocking { fetchBooks() } doReturn listOf(book1)
     }
 
-    val repository = BookRepository(api)
+    val repository = BookRepository(api, bookDao)
 
     // WHEN
     val flow = repository.fetchBook(TEST_ISBN)
@@ -49,7 +58,11 @@ class BookRepositoryTest {
       onBlocking { fetchBooks() } doAnswer { throw IOException() }
     }
 
-    val repository = BookRepository(api)
+    val bookDao = mock<BookDao> {
+      onBlocking { fetchBooks() } doReturn emptyList()
+    }
+
+    val repository = BookRepository(api, bookDao)
 
     // WHEN
     val flow = repository.fetchBook(TEST_ISBN)
@@ -61,36 +74,108 @@ class BookRepositoryTest {
   }
 
   @Test
-  fun `when should force refresh, correct network api is called`() = runBlockingTest {
+  fun `when should not force refresh and local data present, returns local data`() =
+    runBlockingTest {
+      // GIVEN
+      val book1 = Book(
+        title = "book1",
+        contributor = "author1",
+        imageUrl = "http://www.example.com",
+        isbn = TEST_ISBN
+      )
+
+      val bookDao = mock<BookDao> {
+        onBlocking { fetchBooks() } doReturn listOf(book1)
+      }
+
+      val api = mock<Api> {
+        onBlocking { fetchBooks() } doReturn emptyList()
+      }
+
+      val repository = BookRepository(api, bookDao)
+
+      // WHEN
+      val flow = repository.fetchBook(TEST_ISBN, forceRefresh = false)
+
+      // THEN
+      flow.collect { result: Result<Book> ->
+        assertTrue { result.isSuccess }
+        assertEquals(book1, result.getOrNull())
+      }
+      verify(api, never()).fetchBooks()
+    }
+
+  @Test
+  fun `when should not force refresh and local data not present, gets remote data and caches it`() =
+    runBlockingTest {
+      // GIVEN
+      val book1 = Book(
+        title = "book1",
+        contributor = "author1",
+        imageUrl = "http://www.example.com",
+        isbn = TEST_ISBN
+      )
+
+      val bookDao = mock<BookDao> {
+        onBlocking { fetchBooks() } doReturn emptyList()
+      }
+
+      val api = mock<Api> {
+        onBlocking { fetchBooks() } doReturn listOf(book1)
+      }
+
+      val repository = BookRepository(api, bookDao)
+
+      // WHEN
+      val flow = repository.fetchBook(TEST_ISBN, forceRefresh = false)
+
+      // THEN
+      flow.collect { result: Result<Book> ->
+        assertTrue { result.isSuccess }
+        assertEquals(book1, result.getOrNull())
+      }
+
+      inOrder(bookDao, api) {
+        verify(bookDao).fetchBooks()
+        verify(api).fetchBooks()
+        verify(bookDao).insertBooks(listOf(book1))
+      }
+    }
+
+  @Test
+  fun `when should force refresh, gets remote data and caches it`() = runBlockingTest {
     // GIVEN
-    val api = mock<Api> {
+    val book1 = Book(
+      title = "book1",
+      contributor = "author1",
+      imageUrl = "http://www.example.com",
+      isbn = TEST_ISBN
+    )
+
+    val bookDao = mock<BookDao> {
       onBlocking { fetchBooks() } doReturn emptyList()
     }
 
-    val repository = BookRepository(api)
+    val api = mock<Api> {
+      onBlocking { fetchBooks() } doReturn listOf(book1)
+    }
+
+    val repository = BookRepository(api, bookDao)
 
     // WHEN
     val flow = repository.fetchBook(TEST_ISBN, forceRefresh = true)
-    flow.collect()
 
     // THEN
-    verify(api).fetchBooksForceRefresh()
-  }
-
-  @Test
-  fun `when should not force refresh, correct network api is called`() = runBlockingTest {
-    // GIVEN
-    val api = mock<Api> {
-      onBlocking { fetchBooks() } doReturn emptyList()
+    flow.collect { result: Result<Book> ->
+      assertTrue { result.isSuccess }
+      assertEquals(book1, result.getOrNull())
     }
 
-    val repository = BookRepository(api)
+    verify(bookDao, never()).fetchBooks()
 
-    // WHEN
-    val flow = repository.fetchBook(TEST_ISBN)
-    flow.collect()
-
-    // THEN
-    verify(api).fetchBooks()
+    inOrder(bookDao, api) {
+      verify(api).fetchBooks()
+      verify(bookDao).insertBooks(listOf(book1))
+    }
   }
 }


### PR DESCRIPTION
# Summary

Implementation of offline mode. 

**While doing it, I removed http caching as it seems unnecessary anymore. Pull to refresh by user is an intention to get up-to-date non-cached data from remote endpoint.**

## The flow:
* If `forceRefresh` is `false` or not passed in (by default it's `false`), try fetching data from local database (implemented using Room library). If local data is present, return it. Otherwise, fetch data from api, cache it locally and return it.
*  If `forceRefresh` is `true`, fetch data from api, cache it locally and return it.

# Testing
Manual testing using Pixel 2XL/OS 10 to confirm api calls are only made where appropriate and added unit tests for offline mode logic