### PR TITLE
Provide more feedback to user about error type

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.jshvarts.healthreads">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:name=".HealthReadsApplication"

--- a/app/src/main/java/com/jshvarts/healthreads/HealthReadsApplication.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/HealthReadsApplication.kt
@@ -3,6 +3,7 @@ package com.jshvarts.healthreads
 import android.app.Application
 import com.jshvarts.healthreads.di.networkModule
 import com.jshvarts.healthreads.di.repoModule
+import com.jshvarts.healthreads.di.uiHelperModule
 import com.jshvarts.healthreads.di.viewModelModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
@@ -18,7 +19,7 @@ class HealthReadsApplication : Application() {
     startKoin {
       androidLogger(Level.DEBUG)
       androidContext(this@HealthReadsApplication)
-      modules(listOf(repoModule, networkModule, viewModelModule))
+      modules(listOf(repoModule, networkModule, viewModelModule, uiHelperModule))
     }
 
     if (BuildConfig.DEBUG) {

--- a/app/src/main/java/com/jshvarts/healthreads/di/uiHelperModule.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/di/uiHelperModule.kt
@@ -1,0 +1,9 @@
+package com.jshvarts.healthreads.di
+
+import com.jshvarts.healthreads.ui.ConnectionHelper
+import org.koin.android.ext.koin.androidApplication
+import org.koin.dsl.module
+
+val uiHelperModule = module {
+  single { ConnectionHelper(androidApplication()) }
+}

--- a/app/src/main/java/com/jshvarts/healthreads/di/viewModelModule.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/di/viewModelModule.kt
@@ -6,6 +6,6 @@ import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val viewModelModule = module {
-  viewModel { BookListViewModel(get()) }
-  viewModel { BookDetailViewModel(get()) }
+  viewModel { BookListViewModel(get(), get()) }
+  viewModel { BookDetailViewModel(get(), get()) }
 }

--- a/app/src/main/java/com/jshvarts/healthreads/ui/ConnectionHelper.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/ui/ConnectionHelper.kt
@@ -1,0 +1,26 @@
+package com.jshvarts.healthreads.ui
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
+import android.net.NetworkCapabilities.TRANSPORT_ETHERNET
+import android.net.NetworkCapabilities.TRANSPORT_WIFI
+
+class ConnectionHelper(private val context: Context) {
+  fun isConnected(): Boolean {
+    val connectivityManager = context
+      .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    val network = connectivityManager.activeNetwork ?: return false
+
+    val capabilities =
+      connectivityManager.getNetworkCapabilities(network) ?: return false
+
+    return when {
+      capabilities.hasTransport(TRANSPORT_WIFI) ||
+        capabilities.hasTransport(TRANSPORT_CELLULAR) ||
+        capabilities.hasTransport(TRANSPORT_ETHERNET) -> true
+      else -> false
+    }
+  }
+}

--- a/app/src/main/java/com/jshvarts/healthreads/ui/ErrorType.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/ui/ErrorType.kt
@@ -1,0 +1,6 @@
+package com.jshvarts.healthreads.ui
+
+enum class ErrorType {
+  CONNECTION,
+  GENERIC
+}

--- a/app/src/main/java/com/jshvarts/healthreads/ui/bookdetail/BookDetailViewModel.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/ui/bookdetail/BookDetailViewModel.kt
@@ -3,6 +3,8 @@ package com.jshvarts.healthreads.ui.bookdetail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jshvarts.healthreads.data.BookRepository
+import com.jshvarts.healthreads.ui.ConnectionHelper
+import com.jshvarts.healthreads.ui.ErrorType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
@@ -11,7 +13,8 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class BookDetailViewModel(
-  private val bookRepository: BookRepository
+  private val bookRepository: BookRepository,
+  private val connectionHelper: ConnectionHelper
 ) : ViewModel() {
 
   private val _viewState = MutableStateFlow<DetailViewState>(DetailViewState.Loading)
@@ -31,7 +34,11 @@ class BookDetailViewModel(
             }
             result.isFailure -> {
               Timber.e(result.exceptionOrNull(), "error getting book detail")
-              _viewState.value = DetailViewState.Error
+              _viewState.value = if (connectionHelper.isConnected()) {
+                DetailViewState.Error(ErrorType.GENERIC)
+              } else {
+                DetailViewState.Error(ErrorType.CONNECTION)
+              }
             }
           }
         }

--- a/app/src/main/java/com/jshvarts/healthreads/ui/bookdetail/DetailViewState.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/ui/bookdetail/DetailViewState.kt
@@ -1,9 +1,10 @@
 package com.jshvarts.healthreads.ui.bookdetail
 
 import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.ui.ErrorType
 
 sealed class DetailViewState {
   object Loading : DetailViewState()
-  object Error : DetailViewState()
+  data class Error(val type: ErrorType) : DetailViewState()
   data class Data(val book: Book) : DetailViewState()
 }

--- a/app/src/main/java/com/jshvarts/healthreads/ui/booklist/BookListViewModel.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/ui/booklist/BookListViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jshvarts.healthreads.data.BookRepository
+import com.jshvarts.healthreads.ui.ConnectionHelper
+import com.jshvarts.healthreads.ui.ErrorType
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onStart
@@ -12,7 +14,8 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class BookListViewModel(
-  private val bookRepository: BookRepository
+  private val bookRepository: BookRepository,
+  private val connectionHelper: ConnectionHelper
 ) : ViewModel() {
 
   private val _viewState = MutableLiveData<BookListViewState>()
@@ -25,7 +28,11 @@ class BookListViewModel(
           _viewState.value = BookListViewState.Loading
         }.catch { throwable ->
           Timber.e(throwable, "error getting book list")
-          _viewState.value = BookListViewState.Error
+          _viewState.value = if (connectionHelper.isConnected()) {
+            BookListViewState.Error(ErrorType.GENERIC)
+          } else {
+            BookListViewState.Error(ErrorType.CONNECTION)
+          }
         }.collect { bookList ->
           _viewState.value = BookListViewState.Data(bookList)
         }

--- a/app/src/main/java/com/jshvarts/healthreads/ui/booklist/BookListViewState.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/ui/booklist/BookListViewState.kt
@@ -1,9 +1,10 @@
 package com.jshvarts.healthreads.ui.booklist
 
 import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.ui.ErrorType
 
 sealed class BookListViewState {
   object Loading : BookListViewState()
-  object Error : BookListViewState()
+  data class Error(val type: ErrorType) : BookListViewState()
   data class Data(val books: List<Book>) : BookListViewState()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,8 +2,8 @@
     <string name="app_name">Health Reads</string>
     <string name="nav_title_book_detail">Book Detail</string>
     <string name="nav_title_add_book">Add a Book</string>
-    <string name="error_message">Error loading data. Try again later.</string>
-    <string name="refresh_button_text">Refresh</string>
+    <string name="generic_error_message">Error loading data. Please try again later.</string>
+    <string name="error_message_offline">You are currently offline.</string>
     <string name="book_cover_image_description">Book cover image</string>
     <string name="add_book">Add a book</string>
 </resources>


### PR DESCRIPTION
# Summary

Now that the app has offline mode, it's good to give user more specific error messaging when they are offline and cannot refresh data. This PR introduces checking for connection before displaying error snackbar.

# Testing
Manual testing on Pixel 2XL/OS 10 and updated unit tests.

![offline-messaging](https://user-images.githubusercontent.com/5749794/93603932-b24aa800-f992-11ea-877f-e11416ee8a87.png)

