### PR TITLE
Move contents of domain package into data model

### DIFF
--- a/app/src/main/java/com/jshvarts/healthreads/data/BookRepository.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/data/BookRepository.kt
@@ -2,7 +2,7 @@ package com.jshvarts.healthreads.data
 
 import com.jshvarts.healthreads.data.network.Api
 import com.jshvarts.healthreads.data.persistence.BookDao
-import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.data.model.Book
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow

--- a/app/src/main/java/com/jshvarts/healthreads/data/model/Book.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/data/model/Book.kt
@@ -1,4 +1,4 @@
-package com.jshvarts.healthreads.domain
+package com.jshvarts.healthreads.data.model
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey

--- a/app/src/main/java/com/jshvarts/healthreads/data/model/BooksJsonAdapter.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/data/model/BooksJsonAdapter.kt
@@ -1,4 +1,4 @@
-package com.jshvarts.healthreads.domain
+package com.jshvarts.healthreads.data.model
 
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.JsonClass

--- a/app/src/main/java/com/jshvarts/healthreads/data/network/Api.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/data/network/Api.kt
@@ -1,8 +1,8 @@
 package com.jshvarts.healthreads.data.network
 
 import com.jshvarts.healthreads.BuildConfig
-import com.jshvarts.healthreads.domain.Book
-import com.jshvarts.healthreads.domain.WrappedBookList
+import com.jshvarts.healthreads.data.model.Book
+import com.jshvarts.healthreads.data.model.WrappedBookList
 import retrofit2.http.GET
 
 private const val API_KEY = BuildConfig.NYT_API_KEY

--- a/app/src/main/java/com/jshvarts/healthreads/data/persistence/BookDao.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/data/persistence/BookDao.kt
@@ -4,7 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.data.model.Book
 
 @Dao
 interface BookDao {

--- a/app/src/main/java/com/jshvarts/healthreads/data/persistence/BookDatabase.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/data/persistence/BookDatabase.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
-import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.data.model.Book
 
 private const val DATABASE_VERSION = 1
 

--- a/app/src/main/java/com/jshvarts/healthreads/di/networkModule.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/di/networkModule.kt
@@ -1,7 +1,7 @@
 package com.jshvarts.healthreads.di
 
 import com.jshvarts.healthreads.data.network.Api
-import com.jshvarts.healthreads.domain.BooksJsonAdapter
+import com.jshvarts.healthreads.data.model.BooksJsonAdapter
 import com.squareup.moshi.Moshi
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor

--- a/app/src/main/java/com/jshvarts/healthreads/ui/bookdetail/BookDetailFragment.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/ui/bookdetail/BookDetailFragment.kt
@@ -12,7 +12,7 @@ import coil.load
 import com.google.android.material.snackbar.Snackbar
 import com.jshvarts.healthreads.R
 import com.jshvarts.healthreads.databinding.FragmentBookDetailBinding
-import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.data.model.Book
 import com.jshvarts.healthreads.ui.ErrorType
 import com.jshvarts.healthreads.util.exhaustive
 import kotlinx.coroutines.flow.collect

--- a/app/src/main/java/com/jshvarts/healthreads/ui/bookdetail/DetailViewState.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/ui/bookdetail/DetailViewState.kt
@@ -1,6 +1,6 @@
 package com.jshvarts.healthreads.ui.bookdetail
 
-import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.data.model.Book
 import com.jshvarts.healthreads.ui.ErrorType
 
 sealed class DetailViewState {

--- a/app/src/main/java/com/jshvarts/healthreads/ui/booklist/BookListAdapter.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/ui/booklist/BookListAdapter.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.jshvarts.healthreads.databinding.ItemBookBinding
-import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.data.model.Book
 
 class BookListAdapter(
   private val clickListener: (Book, ImageView) -> Unit

--- a/app/src/main/java/com/jshvarts/healthreads/ui/booklist/BookListFragment.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/ui/booklist/BookListFragment.kt
@@ -16,7 +16,7 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
 import com.jshvarts.healthreads.R
 import com.jshvarts.healthreads.databinding.FragmentBookListBinding
-import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.data.model.Book
 import com.jshvarts.healthreads.ui.ErrorType
 import com.jshvarts.healthreads.util.exhaustive
 import org.koin.androidx.viewmodel.ext.android.viewModel

--- a/app/src/main/java/com/jshvarts/healthreads/ui/booklist/BookListViewState.kt
+++ b/app/src/main/java/com/jshvarts/healthreads/ui/booklist/BookListViewState.kt
@@ -1,6 +1,6 @@
 package com.jshvarts.healthreads.ui.booklist
 
-import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.data.model.Book
 import com.jshvarts.healthreads.ui.ErrorType
 
 sealed class BookListViewState {

--- a/app/src/test/java/com/jshvarts/healthreads/data/BookRepositoryTest.kt
+++ b/app/src/test/java/com/jshvarts/healthreads/data/BookRepositoryTest.kt
@@ -2,7 +2,7 @@ package com.jshvarts.healthreads.data
 
 import com.jshvarts.healthreads.data.network.Api
 import com.jshvarts.healthreads.data.persistence.BookDao
-import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.data.model.Book
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.inOrder

--- a/app/src/test/java/com/jshvarts/healthreads/ui/booklist/BookListViewModelTest.kt
+++ b/app/src/test/java/com/jshvarts/healthreads/ui/booklist/BookListViewModelTest.kt
@@ -3,7 +3,7 @@ package com.jshvarts.healthreads.ui.booklist
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.jshvarts.healthreads.data.BookRepository
-import com.jshvarts.healthreads.domain.Book
+import com.jshvarts.healthreads.data.model.Book
 import com.jshvarts.healthreads.threading.CoroutineTestRule
 import com.jshvarts.healthreads.ui.ConnectionHelper
 import com.jshvarts.healthreads.ui.ErrorType


### PR DESCRIPTION
# Summary

This drops `domain` package and move its contents into `data.model` package. At the moment, keeping package called domain while all it has is models, is misleading.
